### PR TITLE
issue-01 fix, project clean compile and build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
         </dependency>
         <dependency>
             <groupId>net.sf.barcode4j</groupId>
-            <artifactId>barcode4j-light</artifactId>
+            <artifactId>barcode4j</artifactId>
             <version>2.1</version>
         </dependency>
     </dependencies>


### PR DESCRIPTION
2.1 version of barcode4j-light is not available for compile and build from [public repo](http://search.maven.org/#search%7Cga%7C1%7Cbarcode4j-light).

This will resolve the issue #1 