### PR TITLE
Change primeface version to 5.3-RC1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
                 <dependency>
                     <groupId>org.primefaces</groupId>
                     <artifactId>primefaces</artifactId>
-                    <version>5.3-SNAPSHOT</version>
+                    <version>5.3-RC1</version>
                 </dependency>
                 <dependency>
                     <groupId>org.glassfish</groupId>


### PR DESCRIPTION
cloned the latest primefaces show case found primefaces version 5.3-SNAPSHOT is not resolvable.
From http://repository.primefaces.org/org/primefaces/primefaces/ found that 5.3.RC1 only exists.