### PR TITLE
fixes #61 - background colors of color picker showcase are not shown

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,13 +199,13 @@
             </activation>
             <properties>
                 <jsfVersion>Mojarra-2.3.2</jsfVersion>
-                <primefacesVersion>PrimeFaces-6.2.RC2-SNAPSHOT</primefacesVersion>
+                <primefacesVersion>PrimeFaces-6.2-SNAPSHOT</primefacesVersion>
             </properties>
             <dependencies>
                 <dependency>
                     <groupId>org.primefaces</groupId>
                     <artifactId>primefaces</artifactId>
-                    <version>6.2.RC2-SNAPSHOT</version>
+                    <version>6.2-SNAPSHOT</version>
                 </dependency>
                 <dependency>
                     <groupId>org.glassfish</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -199,13 +199,13 @@
             </activation>
             <properties>
                 <jsfVersion>Mojarra-2.3.2</jsfVersion>
-                <primefacesVersion>PrimeFaces-6.2-SNAPSHOT</primefacesVersion>
+                <primefacesVersion>PrimeFaces-6.2.RC2-SNAPSHOT</primefacesVersion>
             </properties>
             <dependencies>
                 <dependency>
                     <groupId>org.primefaces</groupId>
                     <artifactId>primefaces</artifactId>
-                    <version>6.2-SNAPSHOT</version>
+                    <version>6.2.RC2-SNAPSHOT</version>
                 </dependency>
                 <dependency>
                     <groupId>org.glassfish</groupId>

--- a/src/main/webapp/ui/input/colorPicker.xhtml
+++ b/src/main/webapp/ui/input/colorPicker.xhtml
@@ -31,10 +31,10 @@
             <p:dialog modal="true" widgetVar="dlg" showEffect="fade" hideEffect="fade" header="Selected Colors" resizable="false">
                 <h:panelGrid id="grid" columns="2" cellpadding="5">
                     <h:outputText value="Inline color: " />
-                    <h:outputText value="#{colorView.colorInline}" style="background-color: \##{colorView.colorInline}" />
+                    <h:outputText value="#{colorView.colorInline}" style="background-color: ##{colorView.colorInline}" />
                     
                     <h:outputText value="Popup color: " />
-                    <h:outputText value="#{colorView.colorPopup}" style="background-color: \##{colorView.colorPopup}" />
+                    <h:outputText value="#{colorView.colorPopup}" style="background-color: ##{colorView.colorPopup}" />
                 </h:panelGrid>
             </p:dialog>     
         </h:form>
@@ -61,10 +61,10 @@
     &lt;p:dialog modal="true" widgetVar="dlg" showEffect="fade" hideEffect="fade" header="Selected Colors" resizable="false"&gt;
         &lt;h:panelGrid id="grid" columns="2" cellpadding="5"&gt;
             &lt;h:outputText value="Inline color: " /&gt;
-            &lt;h:outputText value="\#{colorView.colorInline}" style="background-color: \\#\#{colorView.colorInline}" /&gt;
+            &lt;h:outputText value="#{colorView.colorInline}" style="background-color: \#{colorView.colorInline}" /&gt;
 
             &lt;h:outputText value="Popup color: " /&gt;
-            &lt;h:outputText value="\#{colorView.colorPopup}" style="background-color: \\#\#{colorView.colorPopup}" /&gt;
+            &lt;h:outputText value="\#{colorView.colorPopup}" style="background-color: \#{colorView.colorPopup}" /&gt;
         &lt;/h:panelGrid&gt;
     &lt;/p:dialog&gt; 
 &lt;/h:form&gt;

--- a/src/main/webapp/ui/input/colorPicker.xhtml
+++ b/src/main/webapp/ui/input/colorPicker.xhtml
@@ -61,10 +61,10 @@
     &lt;p:dialog modal="true" widgetVar="dlg" showEffect="fade" hideEffect="fade" header="Selected Colors" resizable="false"&gt;
         &lt;h:panelGrid id="grid" columns="2" cellpadding="5"&gt;
             &lt;h:outputText value="Inline color: " /&gt;
-            &lt;h:outputText value="#{colorView.colorInline}" style="background-color: \#{colorView.colorInline}" /&gt;
+            &lt;h:outputText value="\#{colorView.colorInline}" style="background-color: #\#{colorView.colorInline}" /&gt;
 
             &lt;h:outputText value="Popup color: " /&gt;
-            &lt;h:outputText value="\#{colorView.colorPopup}" style="background-color: \#{colorView.colorPopup}" /&gt;
+            &lt;h:outputText value="\#{colorView.colorPopup}" style="background-color: #\#{colorView.colorPopup}" /&gt;
         &lt;/h:panelGrid&gt;
     &lt;/p:dialog&gt; 
 &lt;/h:form&gt;


### PR DESCRIPTION
- fixed unnecessary, wrong escaping
- additionally updated primefaces version in pom since primefaces repo doesn't contain 6.2-SNAPSHOT anymore