### PR TITLE
closes #79 - use HttpOnly session cookie

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -4,6 +4,13 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd" >
 
+    <session-config>
+        <cookie-config>
+            <http-only>true</http-only>
+        </cookie-config>
+        <tracking-mode>COOKIE</tracking-mode>
+    </session-config>
+    
     <welcome-file-list>
         <welcome-file>/index.xhtml</welcome-file>
     </welcome-file-list>


### PR DESCRIPTION
Can be verified by looking at the response headers:
`Set-Cookie: JSESSIONID=node0q0059kuz3oksrjo75iyzwvme1.node0;Path=/showcase;HttpOnly`

Entering `$.cookie("JSESSIONID")` in browser developer console should return `undefined`.

Btw, normally I'd also declare the session cookie with `<secure>true</secure>` to avoid sending session cookies in plaintext over HTTP. However, we would need a HTTPS connector in jetty-maven-plugin for localhost development then. Apache is redirecting http://www.primefaces.org/showcase to HTTPS anyway by sending `Location: https://www.primefaces.org/showcase/`. Any thoughts?
